### PR TITLE
加入生产环境build配置

### DIFF
--- a/build/utils.js
+++ b/build/utils.js
@@ -47,7 +47,8 @@ exports.cssLoaders = function (options) {
     if (options.extract) {
       return ExtractTextPlugin.extract({
         use: loaders,
-        fallback: 'vue-style-loader'
+        fallback: 'vue-style-loader',
+        // publicPath: '../../'
       })
     } else {
       return ['vue-style-loader'].concat(loaders)

--- a/build/webpack.prod.conf.js
+++ b/build/webpack.prod.conf.js
@@ -24,6 +24,7 @@ const webpackConfig = merge(baseWebpackConfig, {
   devtool: config.build.productionSourceMap ? config.build.devtool : false,
   output: {
     path: config.build.assetsRoot,
+    // publicPath: './',
     filename: utils.assetsPath('js/[name].[chunkhash].js'),
     chunkFilename: utils.assetsPath('js/[id].[chunkhash].js')
   },

--- a/config/index.js
+++ b/config/index.js
@@ -10,6 +10,8 @@ module.exports = {
     // Paths
     assetsSubDirectory: 'static',
     assetsPublicPath: '/',
+    // 打包时使用'./'
+    // assetsPublicPath: './',
     proxyTable: {},
 
     // Various Dev Server settings


### PR DESCRIPTION
开发时候需要注释掉，不然访问不了。
npm run build之前把注释打开即可。